### PR TITLE
Use preface from config for MQTT topics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,8 @@
 mqtt:
     # Specify your MQTT Broker's hostname or IP address here
     host: mqtt
+    # Preface for the topics $PREFACE/$TOPIC
+    preface: dash
 
 buttons:
-    44:65:0d:dc:51:50: dash/nerf_supplies
+    44:65:0d:dc:51:50: nerf_supplies

--- a/server.js
+++ b/server.js
@@ -95,6 +95,9 @@ async.series([
 
         Object.keys(config.buttons).forEach(function (macAddress) {
             var topic = config.buttons[macAddress];
+            if (config.mqtt.preface) {
+              topic = config.mqtt.preface + '/' + topic;
+            }
             buttons[macAddress] = DashButton(macAddress);
             buttons[macAddress].on('detected', buttonEvent.bind(null, macAddress, topic));
         });


### PR DESCRIPTION
This fix lets the user configure the prefix for MQTT topics in the `config.yml` as stated in the README.