### PR TITLE
Add the option to define a port, username and password in the config.yaml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,12 @@
 mqtt:
     # Specify your MQTT Broker's hostname or IP address here
     host: mqtt
+    port: 1883
+    #leave empty if none
+    username:
+    password:
     # Preface for the topics $PREFACE/$TOPIC
     preface: dash
 
 buttons:
-    44:65:0d:dc:51:50: nerf_supplies
+44:65:0d:dc:51:50: nerf_supplies

--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,4 @@ mqtt:
     preface: dash
 
 buttons:
-44:65:0d:dc:51:50: nerf_supplies
+    44:65:0d:dc:51:50: nerf_supplies

--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ async.series([
     },
     function connectToMQTT (next) {
         winston.info('Connecting to MQTT at mqtt://%s', config.mqtt.host);
-		var mqtt_broker_options = config.mqtt;
+	var mqtt_broker_options = config.mqtt;
         broker = mqtt.connect(mqtt_broker_options);
         broker.on('connect', function () {
             next();

--- a/server.js
+++ b/server.js
@@ -83,7 +83,9 @@ async.series([
     },
     function connectToMQTT (next) {
         winston.info('Connecting to MQTT at mqtt://%s', config.mqtt.host);
-        broker = mqtt.connect('mqtt://' + config.mqtt.host);
+        mqtt_broker_options = config.mqtt;
+		winston.info(mqtt_broker_options);
+        broker = mqtt.connect(mqtt_broker_options);
         broker.on('connect', function () {
             next();
             // @TODO Not call this twice if we get disconnected

--- a/server.js
+++ b/server.js
@@ -83,8 +83,7 @@ async.series([
     },
     function connectToMQTT (next) {
         winston.info('Connecting to MQTT at mqtt://%s', config.mqtt.host);
-        mqtt_broker_options = config.mqtt;
-		winston.info(mqtt_broker_options);
+		var mqtt_broker_options = config.mqtt;
         broker = mqtt.connect(mqtt_broker_options);
         broker.on('connect', function () {
             next();


### PR DESCRIPTION
I just set the parsed settings from the config.yaml as object as `options` to [mqtt.connect](https://www.npmjs.com/package/mqtt#connect). By adding username, password and port those settings can be changed. [Accepted values](https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options) will apply.